### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export default [
         port: parseInt(process.env.REDIS_PORT),
         db: parseInt(process.env.REDIS_DB),
         password: process.env.REDIS_PASSWORD,
-        keyPrefix: process.env.REDIS_PRIFIX,
+        keyPrefix: process.env.REDIS_PREFIX,
     },
 ]
 ```


### PR DESCRIPTION
Fixed minor typo in readme.  
`REDIS_PRIFIX`→`REDIS_PREFIX`