### PR TITLE
fix(interface): Change onClientReady return type

### DIFF
--- a/lib/redis.interface.ts
+++ b/lib/redis.interface.ts
@@ -4,7 +4,7 @@ import { Redis, RedisOptions } from 'ioredis';
 export interface RedisModuleOptions extends RedisOptions {
   name?: string;
   url?: string;
-  onClientReady?(client: Redis): Promise<void>;
+  onClientReady?(client: Redis): void;
 }
 
 export interface RedisModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {


### PR DESCRIPTION
This code gives me an error
```
RedisModule.register({
  url: '...',
  onClientReady(client) {}
}),
```

```
Type '(client: Redis) => void' is not assignable to type '(client: Redis) => Promise<void>'.
  Type 'void' is not assignable to type 'Promise<void>'
```

https://github.com/skunight/nestjs-redis/blob/fb30456e178dd377e65c733993ae2b744d09ecea/lib/redis-client.provider.ts#L15-L22

`onClientReady` is not awaited, so `Promise<>` is useless