### PR TITLE
fix(package): rollback to nestjs-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "nest-redis",
-  "version": "1.3.2",
+  "name": "nestjs-redis",
+  "version": "1.3.3",
   "description": "a NestJS ioRedis module",
-  "author": "Stanislav V Vyaliy",
+  "author": "skunight",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wisekaa03/nestjs-ioredis.git"
+    "url": "https://github.com/skunight/nestjs-redis.git"
   },
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.json",


### PR DESCRIPTION
Rollback package name to `nestjs-redis` and repository url to the current one.