### PR TITLE
fix(package): update nestjs, fix CVE-2021-3749

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/../$1',
+  },
+}; 

--- a/lib/__tests__/redis-core.module.spec.ts
+++ b/lib/__tests__/redis-core.module.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RedisCoreModule } from '../redis-core.module';
+import { RedisModuleOptions } from '../redis.interface';
+import { REDIS_MODULE_OPTIONS, REDIS_CLIENT } from '../redis.constants';
+import { RedisService } from '../redis.service';
+
+describe('RedisCoreModule', () => {
+  let testingModule: TestingModule;
+  const mockOptions: RedisModuleOptions = {
+    host: 'localhost',
+    port: 6379,
+  };
+
+  const mockRedisClient = {
+    clients: new Map(),
+    defaultKey: 'default',
+    size: 0,
+  };
+
+  beforeEach(async () => {
+    testingModule = await Test.createTestingModule({
+      providers: [
+        RedisCoreModule,
+        {
+          provide: REDIS_MODULE_OPTIONS,
+          useValue: mockOptions,
+        },
+        {
+          provide: REDIS_CLIENT,
+          useValue: mockRedisClient,
+        },
+        RedisService,
+      ],
+    }).compile();
+  });
+
+  afterEach(async () => {
+    await testingModule.close();
+  });
+
+  describe('register', () => {
+    it('should register module with options', () => {
+      const dynamicModule = RedisCoreModule.register(mockOptions);
+      expect(dynamicModule).toBeDefined();
+      expect(dynamicModule.module).toBe(RedisCoreModule);
+      expect(dynamicModule.providers).toBeDefined();
+      expect(dynamicModule.exports).toContain(RedisService);
+    });
+
+    it('should register module with array of options', () => {
+      const optionsArray: RedisModuleOptions[] = [
+        mockOptions,
+        { ...mockOptions, name: 'second' },
+      ];
+      const dynamicModule = RedisCoreModule.register(optionsArray);
+      expect(dynamicModule).toBeDefined();
+      expect(dynamicModule.module).toBe(RedisCoreModule);
+    });
+  });
+
+  describe('forRootAsync', () => {
+    it('should register module with async options', () => {
+      const asyncOptions = {
+        useFactory: () => mockOptions,
+      };
+      const dynamicModule = RedisCoreModule.forRootAsync(asyncOptions);
+      expect(dynamicModule).toBeDefined();
+      expect(dynamicModule.module).toBe(RedisCoreModule);
+      expect(dynamicModule.providers).toBeDefined();
+      expect(dynamicModule.exports).toContain(RedisService);
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close connections when module is destroyed', async () => {
+      const mockDisconnect = jest.fn();
+
+      mockRedisClient.clients.set('default', { disconnect: mockDisconnect });
+
+      await testingModule.close();
+
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it('should not close connections when keepAlive is true', async () => {
+      const mockDisconnect = jest.fn();
+
+      mockRedisClient.clients.set('default', { disconnect: mockDisconnect });
+
+      // Create a new module with keepAlive option
+      const keepAliveModule = await Test.createTestingModule({
+        providers: [
+          RedisCoreModule,
+          {
+            provide: REDIS_MODULE_OPTIONS,
+            useValue: { ...mockOptions, keepAlive: true },
+          },
+          {
+            provide: REDIS_CLIENT,
+            useValue: mockRedisClient,
+          },
+          RedisService,
+        ],
+      }).compile();
+
+      await keepAliveModule.close();
+
+      expect(mockDisconnect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "eslint -c .eslintrc.js"
   },
   "dependencies": {
-    "@nestjs/common": "^7.4.4",
-    "@nestjs/core": "^7.4.4",
+    "@nestjs/common": "^8.4.7",
+    "@nestjs/core": "^8.4.7",
     "@types/ioredis": "*",
     "@types/uuid": "*",
     "ioredis": "^4",
@@ -30,7 +30,7 @@
     "uuid": "^8"
   },
   "devDependencies": {
-    "@nestjs/testing": "^7",
+    "@nestjs/testing": "^8",
     "@types/node": "*",
     "@typescript-eslint/eslint-plugin": "^4",
     "@typescript-eslint/parser": "^4",


### PR DESCRIPTION
Underlying nestjs/common uses axios 0.21.1 which is subject to https://vulners.com/cve/CVE-2021-3749